### PR TITLE
Allows to retrieve the pid of a process.

### DIFF
--- a/winapi.l.c
+++ b/winapi.l.c
@@ -667,6 +667,13 @@ class Process {
       return push_error(L);
     }
   }
+  
+  /// get the the pid of the process.
+  // @function get_pid
+  def get_pid() {
+    lua_pushnumber(L, this->pid);
+	return 1;
+  }
 
   /// kill the process.
   // @{test-spawn.lua} kills a launched process after a certain amount of output.


### PR DESCRIPTION
This patch allows to retrieve the pid of a process.

``` lua
local proc, file = winapi.spawn_process("aProcess")
print( proc:get_pid() )
```
