### PR TITLE
fix winapi.remove_dir() bugs

### DIFF
--- a/winapi.c
+++ b/winapi.c
@@ -2669,7 +2669,7 @@ static const char *lua_code_block = ""\
   "    end\n"\
   "end\n"\
   "function winapi.make_dir(dir) return exec_cmd('mkdir',dir) end\n"\
-  "function winapi.remove_dir(dir,tree) return exec_cmd('rmdir '.. (tree and '/S'),dir) end\n"\
+  "function winapi.remove_dir(dir,tree) return exec_cmd('rmdir '.. ((tree and '/S /Q') or ''),dir) end\n"\
   "function winapi.delete_file_or_dir(file) return exec_cmd('del',file) end\n"\
   "function winapi.files(mask,subdirs,attrib)\n"\
   "    local flags = '/B '\n"\


### PR DESCRIPTION
1. When tree arg is nil, remove_dir() tries to concat 'rmdir ' with nil. Adding "or ''" fixes this.
2. When target directory is not empty, Windows rmdir command waits for user confirmation. So '/Q' switch is needed.
