### PR TITLE
increased buffer size for wchar string translation

### DIFF
--- a/winapi.c
+++ b/winapi.c
@@ -24,7 +24,7 @@ A useful set of Windows API functions.
 #include <psapi.h>
 
 
-#define WBUFF 2048
+#define WBUFF (32768 * 2)
 #define MAX_SHOW 100
 #define THREAD_STACK_SIZE (1024 * 1024)
 #define MAX_PROCESSES 1024


### PR DESCRIPTION
This buffer needs to hold 32768 wchars including \000 at the end.
This lenght is required to convert lua strings to wchar strings for
CreateProcess() parameters.
see:
https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
